### PR TITLE
Add menu and fog toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Roguelike</title>
     <link rel="manifest" href="/platform/pwa/manifest.webmanifest" />
+    <style>
+      #game {
+        display: inline-block;
+        border: 2px solid #000;
+      }
+    </style>
   </head>
   <body>
     <div id="game"></div>

--- a/src/game/fog.ts
+++ b/src/game/fog.ts
@@ -38,4 +38,8 @@ export class FogOfWar {
     gv.destroy();
     g.destroy();
   }
+
+  setEnabled(enabled: boolean): void {
+    this.rt.setVisible(enabled);
+  }
 }

--- a/src/game/scene.ts
+++ b/src/game/scene.ts
@@ -29,6 +29,7 @@ export class GameScene extends Phaser.Scene {
   private projGraphics!: Phaser.GameObjects.Graphics;
   private remembered = new Set<string>();
   private showSeed = false;
+  private fogEnabled = true;
 
   constructor() {
     super('game');
@@ -36,7 +37,8 @@ export class GameScene extends Phaser.Scene {
 
   preload(): void {}
 
-  create(): void {
+  create(data: { fog?: boolean } = {}): void {
+    this.fogEnabled = data.fog ?? true;
     const px = this.add.graphics();
     px.fillStyle(0xffffff);
     px.fillRect(0, 0, 1, 1);
@@ -70,6 +72,7 @@ export class GameScene extends Phaser.Scene {
     this.hud = new HUD(this, WIDTH * TILE);
     this.projectiles = new ProjectilePool(32);
     this.fog = new FogOfWar(this, WIDTH, HEIGHT, TILE);
+    this.fog.setEnabled(this.fogEnabled);
     this.projGraphics = this.add.graphics();
 
     this.input.keyboard.on(
@@ -157,7 +160,9 @@ export class GameScene extends Phaser.Scene {
       7,
       this.remembered,
     );
-    this.fog.draw(visible, remembered);
+    if (this.fogEnabled) {
+      this.fog.draw(visible, remembered);
+    }
     this.hud.update(
       this.player.stats.hp,
       this.level.depth,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import Phaser from 'phaser';
 import { GameScene } from './game/scene';
+import { MenuScene } from './ui/menu';
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -8,7 +9,8 @@ const config: Phaser.Types.Core.GameConfig = {
   height: 544,
   pixelArt: true,
   roundPixels: true,
-  scene: [GameScene],
+  backgroundColor: '#000000',
+  scene: [MenuScene, GameScene],
   physics: { default: 'arcade' },
 };
 

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -1,0 +1,31 @@
+import Phaser from 'phaser';
+
+export class MenuScene extends Phaser.Scene {
+  private fogEnabled = true;
+  private fogText!: Phaser.GameObjects.Text;
+
+  constructor() {
+    super('menu');
+  }
+
+  create(): void {
+    const { width, height } = this.scale;
+
+    this.add
+      .text(width / 2, height / 2 - 20, 'New Game', { fontSize: '16px' })
+      .setOrigin(0.5)
+      .setInteractive()
+      .on('pointerup', () => {
+        this.scene.start('game', { fog: this.fogEnabled });
+      });
+
+    this.fogText = this.add
+      .text(width / 2, height / 2 + 20, 'Fog: ON', { fontSize: '16px' })
+      .setOrigin(0.5)
+      .setInteractive()
+      .on('pointerup', () => {
+        this.fogEnabled = !this.fogEnabled;
+        this.fogText.setText(`Fog: ${this.fogEnabled ? 'ON' : 'OFF'}`);
+      });
+  }
+}


### PR DESCRIPTION
## Summary
- add simple menu scene with New Game and fog toggle options
- allow disabling fog via menu to diagnose white screen issues
- give game canvas a visible black border and set black background

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b4613758c8320aecbf5986efbbb64